### PR TITLE
Fix error on `set ft=`

### DIFF
--- a/plugin/templates.vim
+++ b/plugin/templates.vim
@@ -31,8 +31,14 @@ let g:templates_empty_files = get(g:, 'templates_empty_files', 0)
 
 augroup Templates
 autocmd!
-autocmd FileType * if s:isnewfile() | call s:loadtemplate( &filetype ) | endif
+autocmd FileType * if s:isnewfile() | call s:loadcurrent() | endif
 augroup END
+
+function! s:loadcurrent()
+	if &filetype
+		call s:loadtemplate(&filetype)
+	endif
+endfunction
 
 function! s:loadtemplate( filetype )
 	let templates = split( globpath( &runtimepath, 'templates/' . a:filetype ), "\n" )


### PR DESCRIPTION
If you set the filetype for the current buffer to an empty value, the
function called in the autocmd errors out. This makes sure the function
is only called for existing filetypes.
